### PR TITLE
Rename to @metamask/mobile-provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-# metamask-mobile-provider
+# @metamask/mobile-provider
 
-This package generates the javascript code that's injected on every webpage when using MetaMask Mobile.
+This package generates the JavaScript code that's injected on every web page when using MetaMask Mobile.
 
-It includes `metamask-inpage-provider` and `web3` as a dependencies and it's intended to be up to date with the latest extension implementation: 
-
-https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/contentscript.js
-
+It includes `@metamask/inpage-provider` and `web3` as a dependencies and it's intended to be up to date with the [latest extension implementation](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/contentscript.js).
 
 To build this package you can run:
 
-`yarn install`
-
-`yarn bundle`
-
+```shell
+yarn && yarn bundle
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "metamask-mobile-provider",
-  "version": "1.1.0",
+  "name": "@metamask/mobile-provider",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -13,9 +13,17 @@
     "lint": "eslint . --ext js,json",
     "lint:fix": "eslint . --ext js,json --fix"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MetaMask/mobile-provider.git"
+  },
   "author": "MetaMask",
   "license": "ISC",
-  "description": "",
+  "description": "The JavaScript injected into every web page in the MetaMask Mobile browser.",
+  "bugs": {
+    "url": "https://github.com/MetaMask/mobile-provider/issues"
+  },
+  "homepage": "https://github.com/MetaMask/mobile-provider#readme",
   "husky": {
     "hooks": {
       "pre-commit": "yarn bundle"


### PR DESCRIPTION
Rename package from `metamask-mobile-provider` to `@metamask/mobile-provider` following the new convention.