### PR TITLE
Add files key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
       "pre-commit": "yarn bundle"
     }
   },
+  "files": [
+    "dist/index.js"
+  ],
   "devDependencies": {
     "@babel/core": "^7.7.2",
     "@babel/plugin-proposal-class-properties": "^7.7.0",


### PR DESCRIPTION
Only publish `dist/index.js` plus required files. I tested this an it works. If you look at the `build.sh` script in `metamask-mobile`, that's the only file used to create the `InpageBridgeWeb3.js` file.