### PR TITLE
Don't use npx to run webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:inpage": "cd src/inpage && npx webpack --config webpack.config.js",
-    "build:dev:inpage": "cd src/inpage && npx webpack --mode=development --config webpack.config.js",
+    "build:inpage": "cd src/inpage && webpack --config webpack.config.js",
+    "build:dev:inpage": "cd src/inpage && webpack --mode=development --config webpack.config.js",
     "bundle:inpage": "node src/content-script/wrapper.js",
     "bundle:contentscript": "concat-cli -f src/content-script/inpage-bundle.js src/content-script/index.js -o dist/index.js",
     "bundle": "yarn build:inpage && yarn bundle:inpage && yarn bundle:contentscript",


### PR DESCRIPTION
This PR updates the `build:*` script entries to use `webpack` directly, removing the unneeded npx indirection.